### PR TITLE
Feature: Display Abstraction and new Display-type

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -27,10 +27,10 @@ jobs:
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
       - name: Check with isort
-        run: poetry run isort -cvl 120 dotmatrix
+        run: poetry run isort -cv --profile black dotmatrix
       - name: Check with pydocstyle
         run: poetry run pydocstyle -v dotmatrix
       - name: Check with black
-        run: black --check -v dotmatrix
+        run: poetry run black --check -v dotmatrix
       - name: Check with mypy
-        run: mypy dotmatrix
+        run: poetry run mypy dotmatrix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         name: Sort python imports
         stages: [commit]
         language: system
-        entry: poetry run isort -l 120
+        entry: poetry run isort --profile black
         types: [python]
     -   id: black
         name: Format python code

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ from dotmatrix import Matrix
 
 m = Matrix(64, 64)
 
-n.rectangle((0, 0), (63, 63))
+m.rectangle((0, 0), (63, 63))
 m.plotf(
     lambda x: 0.005 * x ** 3,
     range(-31, 31),

--- a/dotmatrix/__init__.py
+++ b/dotmatrix/__init__.py
@@ -1,6 +1,6 @@
-from .display import *
+from .displays import *
 from .matrix import *
 
 __version__ = "0.2.0"
 
-__all__ = matrix.__all__ + display.__all__  # type: ignore
+__all__ = matrix.__all__ + displays.__all__  # type: ignore

--- a/dotmatrix/__init__.py
+++ b/dotmatrix/__init__.py
@@ -1,5 +1,6 @@
-from .matrix import Matrix
+from .display import *
+from .matrix import *
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
-__all__ = ["Matrix"]
+__all__ = matrix.__all__ + display.__all__  # type: ignore

--- a/dotmatrix/__init__.py
+++ b/dotmatrix/__init__.py
@@ -1,6 +1,6 @@
-from .displays import *
-from .matrix import *
+from . import displays
+from .matrix import Matrix
 
 __version__ = "0.2.0"
 
-__all__ = matrix.__all__ + displays.__all__  # type: ignore
+__all__ = ("Matrix", "displays")

--- a/dotmatrix/_types.py
+++ b/dotmatrix/_types.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Iterable, Protocol, Tuple, TypeVar, Union
+
+V = TypeVar("V")
+O = TypeVar("O", covariant=True)
+
+Point = Tuple[int, int]
+PointF = Tuple[float, float]
+
+
+class UseDefault:
+    """Sentinel value type that indicates that the default brush is to be used."""
+
+    @staticmethod
+    def resolve(v: Union[V, UseDefault], default: V) -> V:
+        """Resolve the given value dispute.
+
+        :param v: given value
+        :type v: Union[V, UseDefault]
+        :param default: given default
+        :type default: V
+        :return: the actual value
+        :rtype: V
+        """
+        return default if isinstance(v, UseDefault) else v
+
+
+USE_DEFAULT = UseDefault()
+
+
+class Dotted(Protocol):
+    """An object that can be drawn on a Matrix."""
+
+    def __dots__(self) -> Iterable[Point]:
+        """Generate the pixel positions representing this object.
+
+        :return: pixels to draw
+        :rtype: Iterable[Point]
+        """
+
+
+class Display(Protocol[V, O]):
+    """An object that can be used as a matrix display."""
+
+    width: int
+    height: int
+    default_brush: V
+
+    def __init__(
+        self, width: int, height: int, *, default_brush: Union[V, UseDefault]
+    ) -> None:
+        """Initialize a matrix object.
+
+        :param width: width of the matrix
+        :type width: int
+        :param height: height of the matrix
+        :type height: int
+        """
+
+    def render(self) -> O:
+        """Render the current matrix state.
+
+        :return: render result
+        :rtype: O
+        """
+
+    def __getitem__(self, pos: Point) -> V:
+        """Get the value of a pixel.
+
+        :param pos: position of pixel to get
+        :type pos: Point
+        :raises IndexError: requested pixel is out of the bounds of the matrix
+        :return: state of the pixel
+        :rtype: bool
+        """
+
+    def __setitem__(self, pos: Point, val: V):
+        """Set the value of a pixel.
+
+        :param pos: position of the pixel to set
+        :type pos: Point
+        :param val: the value to set the pixel to
+        :type val: bool
+        :raises IndexError: requested pixel is out of the bounds of the matrix
+        """

--- a/dotmatrix/display.py
+++ b/dotmatrix/display.py
@@ -1,0 +1,91 @@
+from array import array
+from math import ceil
+from typing import List
+
+from ._types import USE_DEFAULT, Point, Union, UseDefault
+
+__all__ = ("BrailleDisplay",)
+
+
+# Position of each bit in braille character, in logical order...
+BIT_POS = [0, 3, 1, 4, 2, 5, 6, 7]
+
+
+class BrailleDisplay:
+    """A matrix made up of braile dots."""
+
+    __slots__ = (
+        "width",
+        "_char_width",
+        "height",
+        "_char_height",
+        "default_brush",
+        "data",
+    )
+
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        *,
+        default_brush: Union[bool, UseDefault] = USE_DEFAULT,
+    ) -> None:
+        """Initialize a matrix object.
+
+        :param width: width of the matrix
+        :type width: int
+        :param height: height of the matrix
+        :type height: int
+        """
+        self.default_brush = USE_DEFAULT.resolve(default_brush, True)
+        self.width = width
+        self.height = height
+        self._char_width = ceil(width / 2)
+        self._char_height = ceil(height / 4)
+        # Use array of unsigned chars for easy data integrity.
+        self.data = array("B", [0 for _ in range(self._char_height * self._char_width)])
+
+    def render(self) -> str:
+        """Render the current matrix state.
+
+        :return: render result
+        :rtype: str
+        """
+        chars = (chr(0x2800 | byte) for byte in self.data)
+        lines: List[str] = []
+        for _ in range(self._char_height):
+            line = ""
+            for _ in range(self._char_width):
+                line += next(chars)
+            lines.append(line)
+        return "\n".join(lines)
+
+    def _pos_to_idx(self, x: int, y: int) -> tuple[int, int]:
+        if not (0 <= x < self.width and 0 <= y < self.height):
+            raise IndexError(f"Out of bounds: {(x,y)}")
+        (cx, dx), (cy, dy) = divmod(x, 2), divmod(y, 4)
+        return cx + cy * self._char_width, BIT_POS[dx + dy * 2]
+
+    def __getitem__(self, pos: Point) -> bool:
+        """Get the value of a pixel.
+
+        :param pos: position of pixel to get
+        :type pos: Point
+        :raises IndexError: requested pixel is out of the bounds of the matrix
+        :return: state of the pixel
+        :rtype: bool
+        """
+        c, i = self._pos_to_idx(*pos)
+        return bool(1 & self.data[c] >> i)
+
+    def __setitem__(self, pos: Point, val: bool):
+        """Set the value of a pixel.
+
+        :param pos: position of the pixel to set
+        :type pos: Point
+        :param val: the value to set the pixel to
+        :type val: bool
+        :raises IndexError: requested pixel is out of the bounds of the matrix
+        """
+        c, i = self._pos_to_idx(*pos)
+        self.data[c] ^= (-val ^ self.data[c]) & (1 << i)

--- a/dotmatrix/displays/__init__.py
+++ b/dotmatrix/displays/__init__.py
@@ -1,3 +1,4 @@
-from .braille import BrailleDisplay
+from .block import Block
+from .braille import Braille
 
-__all__ = ("BrailleDisplay",)
+__all__ = ("Braille", "Block")

--- a/dotmatrix/displays/__init__.py
+++ b/dotmatrix/displays/__init__.py
@@ -1,0 +1,3 @@
+from .braille import BrailleDisplay
+
+__all__ = ("BrailleDisplay",)

--- a/dotmatrix/displays/braille.py
+++ b/dotmatrix/displays/braille.py
@@ -2,7 +2,7 @@ from array import array
 from math import ceil
 from typing import List
 
-from ._types import USE_DEFAULT, Point, Union, UseDefault
+from .._types import USE_DEFAULT, Point, Union, UseDefault
 
 __all__ = ("BrailleDisplay",)
 

--- a/dotmatrix/matrix.py
+++ b/dotmatrix/matrix.py
@@ -13,7 +13,7 @@ from typing import (
 )
 
 from ._types import USE_DEFAULT, Display, Dotted, Point, UseDefault
-from .display import BrailleDisplay
+from .displays import BrailleDisplay
 
 __all__ = ("Matrix",)
 

--- a/dotmatrix/matrix.py
+++ b/dotmatrix/matrix.py
@@ -13,7 +13,7 @@ from typing import (
 )
 
 from ._types import USE_DEFAULT, Display, Dotted, Point, UseDefault
-from .displays import BrailleDisplay
+from .displays import Braille
 
 __all__ = ("Matrix",)
 
@@ -35,7 +35,7 @@ class Matrix(Generic[V, O]):
         height: int,
         *,
         default_brush: Union[V, UseDefault] = USE_DEFAULT,
-        display: Union[Display[V, O], Type[Display[V, O]]] = BrailleDisplay,  # type: ignore
+        display: Union[Display[V, O], Type[Display[V, O]]] = Braille,  # type: ignore
     ) -> None:
         """Initialize a matrix object.
 

--- a/dotmatrix/matrix.py
+++ b/dotmatrix/matrix.py
@@ -1,36 +1,42 @@
-from array import array
-from math import ceil
-from typing import Callable, Iterable, Protocol, Sequence, Tuple, TypeVar, Union
+from __future__ import annotations
+
+from typing import (
+    Callable,
+    Generic,
+    Iterable,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from ._types import USE_DEFAULT, Display, Dotted, Point, UseDefault
+from .display import BrailleDisplay
+
+__all__ = ("Matrix",)
+
 
 T = TypeVar("T")
 S = TypeVar("S")
+V = TypeVar("V")
+O = TypeVar("O")
 
 
-Point = Tuple[int, int]
-PointF = Tuple[float, float]
+class Matrix(Generic[V, O]):
+    """The matrix base class."""
 
+    display: Display[V, O]
 
-class Dotted(Protocol):
-    """An object that can be drawn on a Matrix."""
-
-    def __dots__(self) -> Iterable[Point]:
-        """Generate the pixel positions representing this object.
-
-        :return: pixels to draw
-        :rtype: Iterable[Point]
-        """
-
-
-# Position of each bit in braille character, in logical order...
-BIT_POS = [0, 3, 1, 4, 2, 5, 6, 7]
-
-
-class Matrix:
-    """A matrix made up of braile dots."""
-
-    __slots__ = ("width", "_char_width", "height", "_char_height", "data")
-
-    def __init__(self, width: int, height: int) -> None:
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        *,
+        default_brush: Union[V, UseDefault] = USE_DEFAULT,
+        display: Union[Display[V, O], Type[Display[V, O]]] = BrailleDisplay,  # type: ignore
+    ) -> None:
         """Initialize a matrix object.
 
         :param width: width of the matrix
@@ -38,59 +44,61 @@ class Matrix:
         :param height: height of the matrix
         :type height: int
         """
-        self.width = width
-        self.height = height
-        self._char_width = ceil(width / 2)
-        self._char_height = ceil(height / 4)
-        # Use array of unsigned chars for easy data integrity.
-        self.data = array("B", [0 for _ in range(self._char_height * self._char_width)])
+        if isinstance(display, type):
+            self.display = display(width, height, default_brush=default_brush)
+        elif width == display.width and height == display.height:
+            self.display = display
+            self.display.default_brush = USE_DEFAULT.resolve(
+                default_brush, display.default_brush
+            )
+        else:
+            raise ValueError(
+                "Dimensions of display don't match the given matrix dimensions.\n"
+                "Try using Matrix.from_display to construct a matrix for a given display."
+            )
 
-    def render(self) -> str:
+    @classmethod
+    def from_display(cls, display: Display[V, O]) -> Matrix[V, O]:
+        """Create a matrix for a given display.
+
+        :param display: the display to create the matrix for
+        :type display: Display[V, O]
+        :return: a matrix matching the display
+        :rtype: Matrix[V, O]
+        """
+        return cls(display.width, display.height, display=display)
+
+    def render(self) -> O:
         """Render the current matrix state.
 
         :return: render result
-        :rtype: str
+        :rtype: O
         """
-        chars = (chr(0x2800 | byte) for byte in self.data)
-        lines: list[str] = []
-        for _ in range(self._char_height):
-            line = ""
-            for _ in range(self._char_width):
-                line += next(chars)
-            lines.append(line)
-        return "\n".join(lines)
+        return self.display.render()
 
-    def _pos_to_idx(self, x: int, y: int) -> Point:
-        if not (0 <= x < self.width and 0 <= y < self.height):
-            raise IndexError(f"Out of bounds: {(x,y)}")
-        (cx, dx), (cy, dy) = divmod(x, 2), divmod(y, 4)
-        return cx + cy * self._char_width, BIT_POS[dx + dy * 2]
-
-    def __getitem__(self, pos: Point) -> bool:
+    def __getitem__(self, pos: Point) -> V:
         """Get the value of a pixel.
 
         :param pos: position of pixel to get
         :type pos: Point
         :raises IndexError: requested pixel is out of the bounds of the matrix
         :return: state of the pixel
-        :rtype: bool
+        :rtype: V
         """
-        c, i = self._pos_to_idx(*pos)
-        return bool(1 & self.data[c] >> i)
+        return self.display[pos]
 
-    def __setitem__(self, pos: Point, val: bool):
+    def __setitem__(self, pos: Point, val: V):
         """Set the value of a pixel.
 
         :param pos: position of the pixel to set
         :type pos: Point
         :param val: the value to set the pixel to
-        :type val: bool
+        :type val: V
         :raises IndexError: requested pixel is out of the bounds of the matrix
         """
-        c, i = self._pos_to_idx(*pos)
-        self.data[c] ^= (-val ^ self.data[c]) & (1 << i)
+        self.display[pos] = val
 
-    def set(self, x: int, y: int, val: bool):
+    def set(self, x: int, y: int, val: Union[V, UseDefault]):
         """Set the value of a pixel.
 
         Doesn't fail on out of bounds!
@@ -103,11 +111,13 @@ class Matrix:
         :type val: bool
         """
         try:
-            self[x, y] = True
+            self[x, y] = (
+                self.display.default_brush if val is USE_DEFAULT else cast(V, val)
+            )
         except IndexError:
             ...
 
-    def get(self, x: int, y: int, *, default: T = None) -> Union[bool, T]:
+    def get(self, x: int, y: int, *, default: T = None) -> Union[V, T]:
         """Set the value of a pixel.
 
         Doesn't fail on out of bounds!
@@ -126,136 +136,75 @@ class Matrix:
         except IndexError:
             return default  # type: ignore
 
-    def scatter(self, *ps: Point, brush: bool = True):
+    def scatter(self, *ps: Point, brush: Union[V, UseDefault] = USE_DEFAULT):
         """Scatter points.
 
         :param *ps: points to scatter on the canvas
         :type ps: Point
-        :param brush: value to set the pixels to, defaults to True
-        :type brush: bool, optional
+        :param brush: value to set the pixels to
+        :type brush: V, optional
+        """
+        self.iscatter(ps, brush=brush)
+
+    def iscatter(self, ps: Iterable[Point], brush: Union[V, UseDefault] = USE_DEFAULT):
+        """Scatter points from an iterator.
+
+        :param ps: points to scatter on the canvas
+        :type ps: Iterable[Point]
+        :param brush: value to set the pixels to
+        :type brush: V, optional
         """
         for x, y in ps:
             self.set(x, y, brush)
 
-    def show(self, obj: Dotted, at: Point = (0, 0), *, brush: bool = True):
+    def show(
+        self,
+        obj: Dotted,
+        at: Point = (0, 0),
+        *,
+        brush: Union[V, UseDefault] = USE_DEFAULT,
+    ):
         """Draw an object implementing the Dotted protocol.
 
         :param obj: the object to draw
         :type obj: Dotted
         :param at: the position to draw the object at, defaults to (0, 0)
         :type at: Point, optional
-        :param brush: value to set the pixels to, defaults to True
-        :type brush: bool, optional
+        :param brush: value to set the pixels to
+        :type brush: V, optional
         """
         x0, y0 = at
-        self.scatter(*((x0 + x, y0 + y) for x, y in obj.__dots__()), brush=brush)
+        self.iscatter(((x0 + x, y0 + y) for x, y in obj.__dots__()), brush=brush)
 
-    def line(self, p0: Point, p1: Point, *, brush: bool = True):
+    def line(self, p0: Point, p1: Point, *, brush: Union[V, UseDefault] = USE_DEFAULT):
         """Draw a line.
 
         :param p0: coordinates of the first point
         :type p0: Point
         :param p1: coordinates of the second point
         :type p1: Point
-        :param brush: value to set the pixels to, defaults to True
-        :type brush: bool, optional
+        :param brush: value to set the pixels to
+        :type brush: V, optional
         :raises IndexError: one of requested pixels is out of the bounds of the matrix
         """
-        (x0, y0), (x1, y1) = p0, p1
-        dx, sx = abs(x1 - x0), [-1, 1][x0 < x1]
-        dy, sy = -abs(y1 - y0), [-1, 1][y0 < y1]
-        err = dx + dy
+        self.iscatter(bresenham_line(p0, p1), brush=brush)
 
-        while 1:
-            self.set(x0, y0, brush)
-            if x0 == x1 and y0 == y1:
-                break
-            e2 = err * 2
-            if e2 >= dy:
-                err += dy
-                x0 += sx
-            if e2 <= dx:
-                err += dx
-                y0 += sy
-
-    def chain(self, *ps: Point, brush: bool = True):
-        """Draw a chain of segments.
-
-        :param *ps: points defining the segements
-        :type ps: Point
-        :param brush: value to set the pixels to, defaults to True
-        :type brush: bool, optional
-        """
-        for seg in zip(ps[:-1], ps[1:]):
-            self.line(*seg, brush=brush)
-
-    def polygon(self, *ps: Point, brush: bool = True):
-        """Draw a polygon.
-
-        :param *ps: in order points of the polygon
-        :type ps: Point
-        :param brush: value to set the pixels to, defaults to True
-        :type brush: bool, optional
-        """
-        for ps in zip(ps, [ps[-1], *ps[:-1]]):
-            self.line(*ps, brush=brush)
-
-    def rectangle(self, c0: Point, c1: Point, *, brush: bool = True):
-        """Draw a rectangle.
-
-        The two given corners must be opposite of one another.
-
-        :param c0: coordinates of the first corner.
-        :type c0: Point
-        :param c1: coordinates of the second corner.
-        :type c1: Point
-        :param brush: value to set the pixels to, defaults to True
-        :type brush: bool, optional
-        """
-        (x0, y0), (x1, y1) = c0, c1
-        self.polygon(c0, (x1, y0), c1, (x0, y1), brush=brush)
-
-    def circle(self, c: Point, r: int, *, brush: bool = True):
+    def circle(self, c: Point, r: int, *, brush: Union[V, UseDefault] = USE_DEFAULT):
         """Draw a circlee.
 
         :param c: coordinates of the circle's center
         :type c: Point
         :param r: radius of the circle
         :type r: int
-        :param brush: value to set the pixels to, defaults to True
-        :type brush: bool, optional
+        :param brush: value to set the pixels to
+        :type brush: V, optional
         :raises IndexError: one of the requested pixels is out of the bounds of the matrix
         """
-        x0, y0 = c
-        f, ddFx, ddFy = 1 - r, 0, -2 * r
-        x, y = 0, r
+        self.iscatter(bresenham_circle(c, r), brush=brush)
 
-        self.scatter(
-            (x0, y0 + r), (x0, y0 - r), (x0 + r, y0), (x0 - r, y0), brush=brush
-        )
-
-        while x < y:
-            if f >= 0:
-                y -= 1
-                ddFy += 2
-                f += ddFy
-            x += 1
-            ddFx += 2
-            f += ddFx + 1
-
-            self.scatter(
-                (x0 + x, y0 + y),
-                (x0 - x, y0 + y),
-                (x0 + x, y0 - y),
-                (x0 - x, y0 - y),
-                (x0 + y, y0 + x),
-                (x0 - y, y0 + x),
-                (x0 + y, y0 - x),
-                (x0 - y, y0 - x),
-                brush=brush,
-            )
-
-    def ellipse(self, c: Point, r1: int, r2: int, *, brush: bool = True):
+    def ellipse(
+        self, c: Point, r1: int, r2: int, *, brush: Union[V, UseDefault] = USE_DEFAULT
+    ):
         """Draw an ellipse.
 
         :param c: x coordinate of the ellipse's center
@@ -264,48 +213,66 @@ class Matrix:
         :type r1: int
         :param r2: vertical radius of the ellipse
         :type r2: int
-        :param brush: value to set the pixels to, defaults to True
-        :type brush: bool, optional
+        :param brush: value to set the pixels to
+        :type brush: V, optional
         :raises IndexError: one of requested pixels is out of the bounds of the matrix
         """
-        x0, y0 = c
-        dx, dy = 0, r2
-        r12, r22 = r1 * r1, r2 * r2
-        err = r22 - (2 * r2 - 1) * r12
+        self.iscatter(bresenham_ellipse(c, r1, r2), brush=brush)
 
-        while 1:
-            self.scatter(
-                (x0 + dx, y0 + dy),
-                (x0 + dx, y0 - dy),
-                (x0 - dx, y0 + dy),
-                (x0 - dx, y0 - dy),
-                brush=brush,
-            )
+    def chain(self, *ps: Point, brush: Union[V, UseDefault] = USE_DEFAULT):
+        """Draw a chain of segments.
 
-            e2 = 2 * err
-            if e2 < (2 * dx + 1) * r22:
-                dx += 1
-                err += (2 * dx + 1) * r22
-            if e2 > -(2 * dy + 1) * r12:
-                dy -= 1
-                err -= (2 * dy - 1) * r12
+        :param *ps: points defining the segements
+        :type ps: Point
+        :param brush: value to set the pixels to
+        :type brush: V, optional
+        """
+        for seg in zip(ps[:-1], ps[1:]):
+            self.line(*seg, brush=brush)
 
-            if dy < 0:
-                break
+    def polygon(self, *ps: Point, brush: Union[V, UseDefault] = USE_DEFAULT):
+        """Draw a polygon.
 
-        while dx < r1:
-            dx += 1
-            self.scatter((x0 + dx, y0), (x0 - dx, y0), brush=brush)
+        :param *ps: in order points of the polygon
+        :type ps: Point
+        :param brush: value to set the pixels to
+        :type brush: V, optional
+        """
+        for ps in zip(ps, [ps[-1], *ps[:-1]]):
+            self.line(*ps, brush=brush)
 
-    def plot(self, xs: Sequence[int], ys: Sequence[int], *, brush: bool = True):
+    def rectangle(
+        self, c0: Point, c1: Point, *, brush: Union[V, UseDefault] = USE_DEFAULT
+    ):
+        """Draw a rectangle.
+
+        The two given corners must be opposite of one another.
+
+        :param c0: coordinates of the first corner.
+        :type c0: Point
+        :param c1: coordinates of the second corner.
+        :type c1: Point
+        :param brush: value to set the pixels to
+        :type brush: V, optional
+        """
+        (x0, y0), (x1, y1) = c0, c1
+        self.polygon(c0, (x1, y0), c1, (x0, y1), brush=brush)
+
+    def plot(
+        self,
+        xs: Sequence[int],
+        ys: Sequence[int],
+        *,
+        brush: Union[V, UseDefault] = USE_DEFAULT,
+    ):
         """Plot a series of XY-coordinates.
 
         :param xs: x coordinates to plot
         :type xs: Sequence[int]
         :param ys: y coordinates to plot
         :type ys: Sequence[int]
-        :param brush: value to set the pixels to, defaults to True
-        :type brush: bool, optional
+        :param brush: value to set the pixels to
+        :type brush: V, optional
         """
         self.chain(*zip(xs, ys), brush=brush)
 
@@ -318,7 +285,7 @@ class Matrix:
         to_x: Callable[[T], int] = round,  # type: ignore
         to_y: Callable[[S], int] = round,  # type: ignore
         transpose: bool = False,
-        brush: bool = True,
+        brush: Union[V, UseDefault] = USE_DEFAULT,
     ):
         """Plot a function.
 
@@ -334,8 +301,8 @@ class Matrix:
         :type to_y: Callable[[S], int], optional
         :param transpose: transpose plot, defaults to False
         :type transpose: bool, optional
-        :param brush: value to set the pixels to, defaults to True
-        :type brush: bool, optional
+        :param brush: value to set the pixels to
+        :type brush: V, optional
         """
         x0, y0 = origin
         coords = [x0 + to_x(x) for x in xs], [y0 + to_y(f(x)) for x in xs]
@@ -345,7 +312,7 @@ class Matrix:
         self,
         *ps: Point,
         steps: int = 0,
-        brush: bool = True,
+        brush: Union[V, UseDefault] = USE_DEFAULT,
     ):
         """Draw a Bezier curve.
 
@@ -354,8 +321,8 @@ class Matrix:
         :param steps: amount steps to take, defaults to a sensible amount
         :type steps: int, optional
         :raises ValueError: raised if to few points are given to define a curve
-        :param brush: value to set the pixels to, defaults to True
-        :type brush: bool, optional
+        :param brush: value to set the pixels to
+        :type brush: V, optional
         """
         if len(ps) < 2:
             raise ValueError("Need at least two points to define a curve.")
@@ -392,3 +359,109 @@ def de_casteljau(t: float, ps: Iterable[Tuple[float, float]]) -> Tuple[float, fl
             x1, y1 = beta[k + 1]
             beta[k] = (x0 * (1 - t) + x1 * t, y0 * (1 - t) + y1 * t)
     return beta[0]
+
+
+def bresenham_line(p0: Point, p1: Point) -> Iterable[Point]:
+    """Bresenham's line drawing algorithm.
+
+    :param p0: coordinates of the first point
+    :type p0: Point
+    :param p1: coordinates of the second point
+    :type p1: Point
+    :yield: points on the line
+    :rtype: Point
+    """
+    (x0, y0), (x1, y1) = p0, p1
+    dx, sx = abs(x1 - x0), [-1, 1][x0 < x1]
+    dy, sy = -abs(y1 - y0), [-1, 1][y0 < y1]
+    err = dx + dy
+
+    while 1:
+        yield (x0, y0)
+        if x0 == x1 and y0 == y1:
+            break
+        e2 = err * 2
+        if e2 >= dy:
+            err += dy
+            x0 += sx
+        if e2 <= dx:
+            err += dx
+            y0 += sy
+
+
+def bresenham_circle(c: Point, r: int) -> Iterable[Point]:
+    """Bresenham's circle drawing algorithm.
+
+    :param c: coordinates of the circle's center
+    :type c: Point
+    :param r: radius of the circle
+    :type r: int
+    :yield: points on the circle
+    :rtype: Point
+    """
+    x0, y0 = c
+    f, ddFx, ddFy = 1 - r, 0, -2 * r
+    x, y = 0, r
+
+    yield from ((x0, y0 + r), (x0, y0 - r), (x0 + r, y0), (x0 - r, y0))
+
+    while x < y:
+        if f >= 0:
+            y -= 1
+            ddFy += 2
+            f += ddFy
+        x += 1
+        ddFx += 2
+        f += ddFx + 1
+
+        yield from (
+            (x0 + x, y0 + y),
+            (x0 - x, y0 + y),
+            (x0 + x, y0 - y),
+            (x0 - x, y0 - y),
+            (x0 + y, y0 + x),
+            (x0 - y, y0 + x),
+            (x0 + y, y0 - x),
+            (x0 - y, y0 - x),
+        )
+
+
+def bresenham_ellipse(c: Point, r1: int, r2: int) -> Iterable[Point]:
+    """Bresenham's ellipse drawing algorithm.
+
+    :param c: x coordinate of the ellipse's center
+    :type c: Point
+    :param r1: horizontal radius of the ellipse
+    :type r1: int
+    :param r2: vertical radius of the ellipse
+    :type r2: int
+    :yield: points on the ellipse
+    :rtype: Point
+    """
+    x0, y0 = c
+    dx, dy = 0, r2
+    r12, r22 = r1 * r1, r2 * r2
+    err = r22 - (2 * r2 - 1) * r12
+
+    while 1:
+        yield from (
+            (x0 + dx, y0 + dy),
+            (x0 + dx, y0 - dy),
+            (x0 - dx, y0 + dy),
+            (x0 - dx, y0 - dy),
+        )
+
+        e2 = 2 * err
+        if e2 < (2 * dx + 1) * r22:
+            dx += 1
+            err += (2 * dx + 1) * r22
+        if e2 > -(2 * dy + 1) * r12:
+            dy -= 1
+            err -= (2 * dy - 1) * r12
+
+        if dy < 0:
+            break
+
+    while dx < r1:
+        dx += 1
+        yield from ((x0 + dx, y0), (x0 - dx, y0))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dotmatrix"
-version = "0.1.1"
+version = "0.2.0"
 description = "A pixel matrix rendered using braille characters."
 license = "GPL-2.0-or-later"
 authors = ["Tim Fischer <me@timfi.com>"]


### PR DESCRIPTION
_Closes #2_

### What's the idea?

One "_nice to have_" feature could be the addition of matrices that use other character sets for rendering. One nice set could be ` ▖▗▘▝▀▄▌▐▚▞▙▛▜▟█`, i.e. a 2x2 grid per character.

### Code

```python
from dotmatrix import BlockMatrix

m = BlockMatrix(16, 8)

m.rectangle((0, 0), (15, 7))

print(m.render())
```


### Output

```plain
▛▀▀▀▀▀▀▜
▌      ▐
▌      ▐
▌      ▐
▌      ▐
▌      ▐
▌      ▐
▙▄▄▄▄▄▄▟
```

_from issue_

---

### How did I accomplish this?

To implement this I added the `Display` protocol/abstraction which describes all methods required for setting/getting pixel values and rendering said values to some useful output. The Braille logic has been moved to such a display (at `dotmatrix.displays.Braille` and remains the default display type. In addition to this I've also implemented a unicode block character display at `dotmatrix.displays.Block`.

**Code**
```python
from dotmatrix import Matrix
from dotmatrix.displays import Block

m = Matrix(16, 16, display=Block)

m.rectangle((0, 0), (15, 15))
m.circle((7, 7), 7)

print(m.render())
```

**Output**
```
█▀▀██▀▀▀▀▀██▀▀▀█
█▄▀         ▀▄ █
█▀           ▀▄█
█             ██
█             ██
██           █ █
█ ▀▄▄     ▄▄▀  █
█▄▄▄▄█████▄▄▄▄▄█
```
